### PR TITLE
Update package.json peer deps Svelte 4.0.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "version": "npm run dist && npm run docs && git add -A"
   },
   "peerDependencies": {
-    "svelte": "^3.53.1"
+    "svelte": "^3.53.1 || ^4.0.5"
   },
   "devDependencies": {
     "@babel/cli": "^7.14.5",
@@ -84,7 +84,7 @@
     "rollup-plugin-terser": "^7.0.2",
     "sirv-cli": "^1.0.12",
     "standard-version": "^9.3.0",
-    "svelte": "^3.53.1 || ^4.2.1",
+    "svelte": "^3.53.1 || ^4.0.5",
     "svelte-check": "^2.9.2",
     "svelte-jester": "^3.0.0",
     "svelte-loader": "^3.1.1",


### PR DESCRIPTION
I've set the min required version to 4.0.5 which is the same as set in the latest sveltekit release